### PR TITLE
Generate correct callback_url

### DIFF
--- a/lib/omniauth/strategies/gumroad.rb
+++ b/lib/omniauth/strategies/gumroad.rb
@@ -27,7 +27,7 @@ module OmniAuth
       end
 
       def callback_url
-        options[:redirect_uri] || super
+        options[:redirect_uri] || full_host + script_name + callback_path
       end
 
       info do


### PR DESCRIPTION
omniauth-oauth2 v1.4.0 stopped overriding callback_url, this brings back the default implementation.
https://github.com/omniauth/omniauth-oauth2/commit/85fdbe117c2a4400d001a6368cc359d88f40abc7

It's the same fix as https://github.com/Shopify/omniauth-shopify-oauth2/pull/32 and others:
https://github.com/omniauth/omniauth-oauth2/pull/82#ref-pullrequest-150936446