### PR TITLE
Allow any omniauth version greater than 1.0 (including 2.x)

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-gumroad (1.0.1)
-      omniauth (~> 1.0)
+      omniauth (>= 1.0)
       omniauth-oauth2 (~> 1.1)
 
 GEM


### PR DESCRIPTION
This is blocking an upgrade to `omniauth`, which in turn is blocking an upgrade to Ruby 3