### PR TITLE
Update omniauth gumroad version and omniauth

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,8 @@
 PATH
   remote: .
   specs:
-    omniauth-gumroad (1.0.1)
-      omniauth (>= 1.0)
+    omniauth-gumroad (1.0.2)
+      omniauth (~> 2.0)
       omniauth-oauth2 (~> 1.1)
 
 GEM
@@ -13,26 +13,31 @@ GEM
       safe_yaml (~> 0.9.0)
     diff-lcs (1.2.5)
     docile (1.1.2)
-    faraday (0.17.1)
-      multipart-post (>= 1.2, < 3)
-    hashie (3.6.0)
-    jwt (2.2.1)
+    faraday (2.7.4)
+      faraday-net_http (>= 2.0, < 3.1)
+      ruby2_keywords (>= 0.0.4)
+    faraday-net_http (3.0.2)
+    hashie (5.0.0)
+    jwt (2.7.0)
     multi_json (1.14.1)
     multi_xml (0.6.0)
-    multipart-post (2.1.1)
-    oauth2 (1.4.2)
-      faraday (>= 0.8, < 2.0)
+    oauth2 (2.0.9)
+      faraday (>= 0.17.3, < 3.0)
       jwt (>= 1.0, < 3.0)
-      multi_json (~> 1.3)
       multi_xml (~> 0.5)
-      rack (>= 1.2, < 3)
-    omniauth (1.9.0)
-      hashie (>= 3.4.6, < 3.7.0)
-      rack (>= 1.6.2, < 3)
-    omniauth-oauth2 (1.6.0)
-      oauth2 (~> 1.1)
-      omniauth (~> 1.9)
+      rack (>= 1.2, < 4)
+      snaky_hash (~> 2.0)
+      version_gem (~> 1.1)
+    omniauth (2.1.1)
+      hashie (>= 3.4.6)
+      rack (>= 2.2.3)
+      rack-protection
+    omniauth-oauth2 (1.8.0)
+      oauth2 (>= 1.4, < 3)
+      omniauth (~> 2.0)
     rack (2.2.3.1)
+    rack-protection (3.0.5)
+      rack
     rack-test (0.6.2)
       rack (>= 1.0)
     rake (13.0.1)
@@ -44,12 +49,17 @@ GEM
     rspec-expectations (2.14.4)
       diff-lcs (>= 1.1.3, < 2.0)
     rspec-mocks (2.14.4)
+    ruby2_keywords (0.0.5)
     safe_yaml (0.9.7)
     simplecov (0.8.2)
       docile (~> 1.1.0)
       multi_json
       simplecov-html (~> 0.8.0)
     simplecov-html (0.8.0)
+    snaky_hash (2.0.1)
+      hashie
+      version_gem (~> 1.1, >= 1.1.1)
+    version_gem (1.1.1)
     webmock (1.17.1)
       addressable (>= 2.2.7)
       crack (>= 0.3.2)
@@ -64,3 +74,6 @@ DEPENDENCIES
   rspec (~> 2.7)
   simplecov
   webmock
+
+BUNDLED WITH
+   2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     omniauth-gumroad (1.0.1)
-      omniauth (~> 1.0)
+      omniauth (>= 1.0)
       omniauth-oauth2 (~> 1.1)
 
 GEM

--- a/lib/omniauth-gumroad/version.rb
+++ b/lib/omniauth-gumroad/version.rb
@@ -1,6 +1,6 @@
 module OmniAuth
   module Gumroad
-    VERSION = "1.0.1"
+    VERSION = "1.0.2"
   end
 end
 

--- a/omniauth-gumroad.gemspec
+++ b/omniauth-gumroad.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |gem|
   gem.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   gem.require_paths = ["lib"]
 
-  gem.add_dependency 'omniauth', '~> 1.0'
+  gem.add_dependency 'omniauth', '~> 2.0'
   gem.add_dependency 'omniauth-oauth2', '~> 1.1'
   gem.add_development_dependency 'rspec', '~> 2.7'
   gem.add_development_dependency 'rack-test'


### PR DESCRIPTION
Flailing about trying to allow us to update omniauth

I do not like that `bundle update omniauth --conservative` wants to start using faraday v2.x